### PR TITLE
feat: remove init asset packs

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,25 +1,9 @@
 // We define the empty imports so the auto-complete feature works as expected.
-import { } from '@dcl/sdk/math'
-import { Animator, AudioSource, AvatarAttach, GltfContainer, Material, Transform, UiBackground, UiText, UiTransform, VideoPlayer, VisibilityComponent, engine, pointerEventsSystem } from '@dcl/sdk/ecs'
-import { initAssetPacks } from '@dcl/asset-packs/dist/scene-entrypoint'
+import {} from '@dcl/sdk/math'
+import { engine } from '@dcl/sdk/ecs'
 
 import { changeColorSystem, circularSystem } from './systems'
 import { setupUi } from './ui'
-
-// You can remove this if you don't use any asset packs
-initAssetPacks(engine, pointerEventsSystem, {
-  Animator,
-  AudioSource,
-  AvatarAttach,
-  Transform,
-  VisibilityComponent,
-  GltfContainer,
-  Material,
-  VideoPlayer,
-  UiTransform,
-  UiText,
-  UiBackground
-})
 
 export function main() {
   // Defining behavior. See `src/systems.ts` file.


### PR DESCRIPTION
Remove `initAssetPacks` related code since it's not necessary anymore from v7.4.9 of the SDK